### PR TITLE
Fix iOS input zoom on mobile

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,0 +1,15 @@
+import { Html, Head, Main, NextScript } from 'next/document'
+
+export default function Document() {
+  return (
+    <Html lang="en">
+      <Head>
+        <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
+      </Head>
+      <body>
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  )
+}


### PR DESCRIPTION
## Summary
- Adds `_document.tsx` with `maximum-scale=1` in the viewport meta tag
- Prevents iOS Safari from zooming in when tapping an input field

## Test plan
- [ ] Tap any input on an iPhone — page should not zoom

https://claude.ai/code/session_01BGC66hhc3XwVVCFZeg61FK