### PR TITLE
Expense editing, member list cleanup, delete confirmations

### DIFF
--- a/components/EditExpenseModal.tsx
+++ b/components/EditExpenseModal.tsx
@@ -1,0 +1,344 @@
+import { useEffect, useState } from 'react'
+import {
+  Box,
+  Input,
+  VStack,
+  Text,
+  HStack,
+  Select,
+  createListCollection,
+  Portal,
+  SimpleGrid,
+} from '@chakra-ui/react'
+import { Button } from '@/components/ui/button'
+import {
+  DialogRoot,
+  DialogContent,
+  DialogHeader,
+  DialogBody,
+  DialogFooter,
+  DialogTitle,
+  DialogCloseTrigger,
+} from '@/components/ui/dialog'
+import { getAPICall, putAPICall, deleteAPICall } from '@/utils/apiManager'
+import { toaster } from '@/components/ui/toaster'
+import { Category, Expense, GroupMember } from '@/types'
+
+interface EditExpenseModalProps {
+  expense: Expense | null
+  onClose: () => void
+  onSaved: () => void
+  groupId: string
+  members: GroupMember[]
+}
+
+export default function EditExpenseModal({
+  expense,
+  onClose,
+  onSaved,
+  groupId,
+  members,
+}: EditExpenseModalProps) {
+  const [description, setDescription] = useState('')
+  const [amount, setAmount] = useState('')
+  const [paidById, setPaidById] = useState('')
+  const [date, setDate] = useState('')
+  const [splitType, setSplitType] = useState('equal')
+  const [exactSplits, setExactSplits] = useState<Record<string, string>>({})
+  const [categoryId, setCategoryId] = useState<string | null>(null)
+  const [categories, setCategories] = useState<Category[]>([])
+  const [loading, setLoading] = useState(false)
+  const [confirmDelete, setConfirmDelete] = useState(false)
+  const [deleting, setDeleting] = useState(false)
+
+  useEffect(() => {
+    if (expense) {
+      setDescription(expense.description)
+      setAmount(String(expense.amount))
+      setPaidById(expense.paid_by_id)
+      setDate(new Date(expense.date).toISOString().split('T')[0])
+      setSplitType(expense.split_type)
+      setCategoryId(expense.category_id ?? null)
+      const splits: Record<string, string> = {}
+      expense.splits.forEach((s) => { splits[s.user_id] = String(s.amount) })
+      setExactSplits(splits)
+      setConfirmDelete(false)
+    }
+  }, [expense])
+
+  useEffect(() => {
+    if (expense && categories.length === 0) {
+      getAPICall('/api/categories').then((data) => { if (data) setCategories(data) })
+    }
+  }, [expense, categories.length])
+
+  const memberCollection = createListCollection({
+    items: members.map((m) => ({ label: m.name, value: m.userId })),
+  })
+
+  const splitTypeCollection = createListCollection({
+    items: [
+      { label: 'Split Equally', value: 'equal' },
+      { label: 'Exact Amounts', value: 'exact' },
+    ],
+  })
+
+  const handleSave = async () => {
+    if (!expense) return
+    if (!description.trim()) {
+      toaster.create({ title: 'Description is required', type: 'error', duration: 3000 })
+      return
+    }
+    const amt = parseFloat(amount)
+    if (isNaN(amt) || amt <= 0) {
+      toaster.create({ title: 'Enter a valid amount', type: 'error', duration: 3000 })
+      return
+    }
+
+    const payload: Record<string, unknown> = {
+      description: description.trim(),
+      amount: amt,
+      paid_by_id: paidById,
+      date,
+      split_type: splitType,
+      category_id: categoryId,
+    }
+
+    if (splitType === 'exact') {
+      payload.splits = members.map((m) => ({
+        user_id: m.userId,
+        amount: parseFloat(exactSplits[m.userId] || '0'),
+      }))
+      const total = (payload.splits as { amount: number }[]).reduce((s, x) => s + x.amount, 0)
+      if (Math.abs(total - amt) > 0.01) {
+        toaster.create({ title: `Splits must add up to $${amt.toFixed(2)}`, type: 'error', duration: 4000 })
+        return
+      }
+    }
+
+    setLoading(true)
+    try {
+      await putAPICall(`/api/groups/${groupId}/expenses/${expense.id}`, payload)
+      toaster.create({ title: 'Expense updated', type: 'success', duration: 3000 })
+      onSaved()
+      onClose()
+    } catch (err) {
+      toaster.create({ title: String(err), type: 'error', duration: 4000 })
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleDelete = async () => {
+    if (!expense) return
+    setDeleting(true)
+    try {
+      await deleteAPICall(`/api/groups/${groupId}/expenses/${expense.id}`)
+      toaster.create({ title: 'Expense deleted', type: 'info', duration: 3000 })
+      onSaved()
+      onClose()
+    } catch (err) {
+      toaster.create({ title: String(err), type: 'error', duration: 4000 })
+    } finally {
+      setDeleting(false)
+    }
+  }
+
+  return (
+    <DialogRoot open={!!expense} onOpenChange={(e) => { if (!e.open) { setConfirmDelete(false); onClose() } }} size="md">
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Edit Expense</DialogTitle>
+          <DialogCloseTrigger />
+        </DialogHeader>
+        <DialogBody>
+          <VStack gap={4} align="stretch">
+            <Box>
+              <Text fontSize="sm" fontWeight="medium" mb={1} color="gray.700">Description</Text>
+              <Input
+                placeholder="e.g. Dinner, Taxi, Groceries"
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                autoFocus
+              />
+            </Box>
+
+            <HStack gap={3}>
+              <Box flex={1}>
+                <Text fontSize="sm" fontWeight="medium" mb={1} color="gray.700">Amount ($)</Text>
+                <Input
+                  placeholder="0.00"
+                  value={amount}
+                  onChange={(e) => setAmount(e.target.value)}
+                  type="number"
+                  min={0}
+                  step={0.01}
+                />
+              </Box>
+              <Box flex={1}>
+                <Text fontSize="sm" fontWeight="medium" mb={1} color="gray.700">Date</Text>
+                <Input
+                  type="date"
+                  value={date}
+                  onChange={(e) => setDate(e.target.value)}
+                />
+              </Box>
+            </HStack>
+
+            <Box>
+              <Text fontSize="sm" fontWeight="medium" mb={2} color="gray.700">Category</Text>
+              <SimpleGrid columns={4} gap={2}>
+                {categories.map((c) => (
+                  <Box
+                    key={c.id}
+                    p={2}
+                    borderRadius="lg"
+                    borderWidth="1.5px"
+                    borderColor={categoryId === c.id ? 'teal.400' : 'gray.100'}
+                    bg={categoryId === c.id ? 'teal.50' : 'white'}
+                    cursor="pointer"
+                    textAlign="center"
+                    _hover={{ borderColor: 'teal.300', bg: 'teal.50' }}
+                    onClick={() => setCategoryId(categoryId === c.id ? null : c.id)}
+                  >
+                    <Text fontSize="xl" lineHeight={1}>{c.emoji}</Text>
+                    <Text fontSize="10px" color="gray.600" mt={1} lineHeight={1.2} lineClamp={2}>{c.name}</Text>
+                  </Box>
+                ))}
+              </SimpleGrid>
+            </Box>
+
+            <Box>
+              <Text fontSize="sm" fontWeight="medium" mb={1} color="gray.700">Paid by</Text>
+              <Select.Root
+                collection={memberCollection}
+                value={[paidById]}
+                onValueChange={(e) => setPaidById(e.value[0])}
+                size="md"
+              >
+                <Select.Trigger>
+                  <Select.ValueText placeholder="Select who paid" />
+                </Select.Trigger>
+                <Portal>
+                  <Select.Positioner>
+                    <Select.Content>
+                      {memberCollection.items.map((item) => (
+                        <Select.Item key={item.value} item={item}>
+                          {item.label}
+                        </Select.Item>
+                      ))}
+                    </Select.Content>
+                  </Select.Positioner>
+                </Portal>
+              </Select.Root>
+            </Box>
+
+            <Box>
+              <Text fontSize="sm" fontWeight="medium" mb={1} color="gray.700">Split</Text>
+              <Select.Root
+                collection={splitTypeCollection}
+                value={[splitType]}
+                onValueChange={(e) => setSplitType(e.value[0])}
+                size="md"
+              >
+                <Select.Trigger>
+                  <Select.ValueText />
+                </Select.Trigger>
+                <Portal>
+                  <Select.Positioner>
+                    <Select.Content>
+                      {splitTypeCollection.items.map((item) => (
+                        <Select.Item key={item.value} item={item}>
+                          {item.label}
+                        </Select.Item>
+                      ))}
+                    </Select.Content>
+                  </Select.Positioner>
+                </Portal>
+              </Select.Root>
+            </Box>
+
+            {splitType === 'exact' && (
+              <Box>
+                <Text fontSize="sm" fontWeight="medium" mb={2} color="gray.700">
+                  Enter each person&apos;s share
+                </Text>
+                <VStack gap={2}>
+                  {members.map((m) => (
+                    <HStack key={m.userId} justify="space-between">
+                      <Text fontSize="sm" flex={1}>{m.name}</Text>
+                      <Input
+                        w="120px"
+                        size="sm"
+                        placeholder="0.00"
+                        type="number"
+                        min={0}
+                        step={0.01}
+                        value={exactSplits[m.userId] || ''}
+                        onChange={(e) =>
+                          setExactSplits((prev) => ({ ...prev, [m.userId]: e.target.value }))
+                        }
+                      />
+                    </HStack>
+                  ))}
+                </VStack>
+                {amount && (
+                  <Text fontSize="xs" color="gray.500" mt={2}>
+                    Total must equal ${parseFloat(amount || '0').toFixed(2)}
+                    {' — '}remaining: ${(
+                      parseFloat(amount || '0') -
+                      members.reduce((s, m) => s + parseFloat(exactSplits[m.userId] || '0'), 0)
+                    ).toFixed(2)}
+                  </Text>
+                )}
+              </Box>
+            )}
+
+            {splitType === 'equal' && amount && members.length > 0 && (
+              <Box p={3} bg="teal.50" borderRadius="md">
+                <Text fontSize="sm" color="teal.700">
+                  Each person pays <Text as="span" fontWeight="bold">${(parseFloat(amount) / members.length).toFixed(2)}</Text>
+                </Text>
+              </Box>
+            )}
+
+            {/* Delete section */}
+            {!confirmDelete ? (
+              <Box pt={2} borderTopWidth="1px" borderColor="gray.100">
+                <Button
+                  variant="ghost"
+                  colorPalette="red"
+                  size="sm"
+                  w="full"
+                  onClick={() => setConfirmDelete(true)}
+                >
+                  Delete Expense
+                </Button>
+              </Box>
+            ) : (
+              <Box p={3} bg="red.50" borderRadius="md" borderWidth="1px" borderColor="red.200">
+                <Text fontSize="sm" fontWeight="medium" color="red.700" mb={3}>
+                  Are you sure? This cannot be undone.
+                </Text>
+                <HStack gap={2}>
+                  <Button variant="outline" size="sm" flex={1} onClick={() => setConfirmDelete(false)}>
+                    Cancel
+                  </Button>
+                  <Button colorPalette="red" size="sm" flex={1} onClick={handleDelete} loading={deleting}>
+                    Yes, Delete
+                  </Button>
+                </HStack>
+              </Box>
+            )}
+          </VStack>
+        </DialogBody>
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose} mr={2}>Cancel</Button>
+          <Button colorPalette="teal" onClick={handleSave} loading={loading}>
+            Save Changes
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </DialogRoot>
+  )
+}

--- a/components/ExpenseItem.tsx
+++ b/components/ExpenseItem.tsx
@@ -1,15 +1,15 @@
 import { Box, Flex, Text, HStack, IconButton } from '@chakra-ui/react'
-import { FiTrash2 } from 'react-icons/fi'
+import { FiEdit2 } from 'react-icons/fi'
 import dayjs from 'dayjs'
 import { Expense } from '@/types'
 import { useAuth } from '@/contexts/AuthContext'
 
 interface ExpenseItemProps {
   expense: Expense
-  onDelete: (id: string) => void
+  onEdit: (expense: Expense) => void
 }
 
-export default function ExpenseItem({ expense, onDelete }: ExpenseItemProps) {
+export default function ExpenseItem({ expense, onEdit }: ExpenseItemProps) {
   const { user } = useAuth()
   const isMyExpense = expense.paid_by_id === user?.id
   const mySplit = expense.splits.find((s) => s.user_id === user?.id)
@@ -76,14 +76,14 @@ export default function ExpenseItem({ expense, onDelete }: ExpenseItemProps) {
             </Text>
           </Box>
           <IconButton
-            aria-label="Delete expense"
+            aria-label="Edit expense"
             variant="ghost"
             size="xs"
             color="gray.400"
-            _hover={{ color: 'red.500', bg: 'red.50' }}
-            onClick={() => onDelete(expense.id)}
+            _hover={{ color: 'teal.500', bg: 'teal.50' }}
+            onClick={() => onEdit(expense)}
           >
-            <FiTrash2 />
+            <FiEdit2 />
           </IconButton>
         </HStack>
       </Flex>

--- a/pages/api/groups/[id]/expenses/[expenseId].ts
+++ b/pages/api/groups/[id]/expenses/[expenseId].ts
@@ -14,6 +14,96 @@ async function handler(req: AuthenticatedRequest, res: NextApiResponse) {
     return res.status(403).json({ error: 'Access denied' })
   }
 
+  if (req.method === 'PUT') {
+    const { description, amount, paid_by_id, date, split_type, splits, category_id } = req.body
+
+    if (!description || !amount || !paid_by_id || !date) {
+      return res.status(400).json({ error: 'description, amount, paid_by_id, and date are required' })
+    }
+
+    const totalAmount = Number(amount)
+    if (isNaN(totalAmount) || totalAmount <= 0) {
+      return res.status(400).json({ error: 'Amount must be a positive number' })
+    }
+
+    const type = split_type || 'equal'
+
+    try {
+      const members = await prisma.groupMember.findMany({
+        where: { groupId, deleted_at: null },
+        select: { userId: true },
+      })
+
+      let expenseSplits: { user_id: string; amount: number }[] = []
+
+      if (type === 'equal') {
+        const splitAmount = Math.round((totalAmount / members.length) * 100) / 100
+        const remainder = Math.round((totalAmount - splitAmount * members.length) * 100) / 100
+        expenseSplits = members.map((m, i) => ({
+          user_id: m.userId,
+          amount: i === 0 ? splitAmount + remainder : splitAmount,
+        }))
+      } else if (type === 'exact' && Array.isArray(splits)) {
+        expenseSplits = splits.map((s: { user_id: string; amount: number }) => ({
+          user_id: s.user_id,
+          amount: Number(s.amount),
+        }))
+      } else {
+        return res.status(400).json({ error: 'Invalid split configuration' })
+      }
+
+      // Delete existing splits and recreate
+      await prisma.expenseSplits.deleteMany({ where: { expense_id: expenseId } })
+
+      const expense = await prisma.expenses.update({
+        where: { id: expenseId },
+        data: {
+          description,
+          amount: totalAmount,
+          paid_by_id,
+          date: new Date(date),
+          split_type: type,
+          category_id: category_id ? BigInt(category_id) : null,
+          splits: {
+            create: expenseSplits.map((s) => ({
+              user_id: s.user_id,
+              amount: s.amount,
+            })),
+          },
+        },
+        include: {
+          paid_by: { select: { id: true, name: true } },
+          category: { select: { id: true, name: true, emoji: true } },
+          splits: { include: { user: { select: { id: true, name: true } } } },
+        },
+      })
+
+      return res.status(200).json({
+        id: expense.id.toString(),
+        description: expense.description,
+        amount: Number(expense.amount),
+        paid_by_id: expense.paid_by_id,
+        paid_by: expense.paid_by,
+        date: expense.date,
+        split_type: expense.split_type,
+        group_id: expense.group_id.toString(),
+        category_id: expense.category_id?.toString() ?? null,
+        category: expense.category
+          ? { id: expense.category.id.toString(), name: expense.category.name, emoji: expense.category.emoji }
+          : null,
+        splits: expense.splits.map((s) => ({
+          id: s.id.toString(),
+          user_id: s.user_id,
+          amount: Number(s.amount),
+          user: s.user,
+        })),
+      })
+    } catch (error) {
+      console.error(error)
+      return res.status(500).json({ error: 'Internal server error' })
+    }
+  }
+
   if (req.method === 'DELETE') {
     try {
       await prisma.expenses.update({

--- a/pages/groups/[id].tsx
+++ b/pages/groups/[id].tsx
@@ -15,7 +15,7 @@ import {
 } from '@chakra-ui/react'
 import { Button } from '@/components/ui/button'
 import { FiArrowLeft, FiPlus, FiUsers, FiDollarSign, FiBarChart2, FiSearch } from 'react-icons/fi'
-import { getAPICall, deleteAPICall, postAPICall } from '@/utils/apiManager'
+import { getAPICall, postAPICall } from '@/utils/apiManager'
 import { toaster } from '@/components/ui/toaster'
 import { Toaster } from '@/components/ui/toaster'
 import { Expense, Group, GroupMember, Settlement, Balance, SimplifiedDebt } from '@/types'
@@ -29,6 +29,7 @@ import {
   DialogCloseTrigger,
 } from '@/components/ui/dialog'
 import AddExpenseModal from '@/components/AddExpenseModal'
+import EditExpenseModal from '@/components/EditExpenseModal'
 import SettleUpModal from '@/components/SettleUpModal'
 import BalanceSummary from '@/components/BalanceSummary'
 import ExpenseItem from '@/components/ExpenseItem'
@@ -52,6 +53,7 @@ export default function GroupDetailPage() {
   const [showAddExpense, setShowAddExpense] = useState(false)
   const [showSettleUp, setShowSettleUp] = useState(false)
   const [showAddMember, setShowAddMember] = useState(false)
+  const [editingExpense, setEditingExpense] = useState<Expense | null>(null)
   const [selectedDebt, setSelectedDebt] = useState<SimplifiedDebt | null>(null)
 
   const fetchAll = useCallback(async () => {
@@ -77,15 +79,6 @@ export default function GroupDetailPage() {
     fetchAll()
   }, [fetchAll])
 
-  const handleDeleteExpense = async (expenseId: string) => {
-    try {
-      await deleteAPICall(`/api/groups/${id}/expenses/${expenseId}`)
-      toaster.create({ title: 'Expense deleted', type: 'info', duration: 3000 })
-      fetchAll()
-    } catch (err) {
-      toaster.create({ title: String(err), type: 'error', duration: 4000 })
-    }
-  }
 
   const handleSettleUp = (debt?: SimplifiedDebt) => {
     setSelectedDebt(debt || null)
@@ -241,7 +234,7 @@ export default function GroupDetailPage() {
               <VStack gap={3} align="stretch">
                 {/* Expenses */}
                 {expenses.map((e) => (
-                  <ExpenseItem key={e.id} expense={e} onDelete={handleDeleteExpense} />
+                  <ExpenseItem key={e.id} expense={e} onEdit={setEditingExpense} />
                 ))}
 
                 {/* Settlements */}
@@ -334,7 +327,6 @@ export default function GroupDetailPage() {
                       <Text fontSize="sm" fontWeight="medium">
                         {m.name} {m.userId === user?.id && <Text as="span" color="gray.400">(you)</Text>}
                       </Text>
-                      <Text fontSize="xs" color="gray.500">{m.mobile}</Text>
                     </Box>
                   </HStack>
                   {(() => {
@@ -376,6 +368,13 @@ export default function GroupDetailPage() {
             groupId={group.id}
             members={group.members}
             suggested={selectedDebt}
+          />
+          <EditExpenseModal
+            expense={editingExpense}
+            onClose={() => setEditingExpense(null)}
+            onSaved={fetchAll}
+            groupId={group.id}
+            members={group.members}
           />
           <AddMemberModal
             open={showAddMember}


### PR DESCRIPTION
## Summary
- Expense list now shows an edit icon instead of delete
- Tapping edit opens a pre-filled modal to update description, amount, date, category, paid by, and split
- Delete is inside the edit modal behind an inline "Are you sure?" confirmation
- Phone numbers removed from the Members tab in group detail
- Admin page user/category deletions already had confirmations (no change needed)

## Test plan
- [ ] Tap edit icon on an expense — modal opens pre-filled with existing values
- [ ] Save changes — expense updates and list refreshes
- [ ] Tap "Delete Expense" — confirmation section appears; cancel dismisses it, confirm deletes
- [ ] Members tab no longer shows phone numbers
- [ ] Admin: deleting a user or category still shows a confirmation prompt

https://claude.ai/code/session_01BGC66hhc3XwVVCFZeg61FK